### PR TITLE
🧹 Remove commented out nvf rust support

### DIFF
--- a/modules/home/editors/neovim/nvf.nix
+++ b/modules/home/editors/neovim/nvf.nix
@@ -99,7 +99,6 @@ in {
         nix.enable = true;
         markdown.enable = true;
         lua.enable = true;
-        # rust.enable = true;
       };
       autocomplete.blink-cmp = {
         enable = true;


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Removed the commented out `# rust.enable = true;` from `modules/home/editors/neovim/nvf.nix` inside the `languages` block.

💡 **Why:** How this improves maintainability
The commented-out code was simply dead code that cluttered the config file. By removing it, the intention of the Nix module becomes clearer and removes the ambiguity of "was this meant to be turned on?".

✅ **Verification:** How you confirmed the change is safe
Ran `git diff` to ensure only this comment line was stripped, causing zero functional modifications and retaining proper valid syntax.

✨ **Result:** The improvement achieved
A slightly cleaner nvf configuration file without any dead commented out blocks in the `languages` configuration section.

---
*PR created automatically by Jules for task [3303817301612221234](https://jules.google.com/task/3303817301612221234) started by @phucisstupid*