### PR TITLE
⚡ Optimize yazi relative motions keymap generation

### DIFF
--- a/modules/home/tools/yazi.nix
+++ b/modules/home/tools/yazi.nix
@@ -5,6 +5,11 @@
   flake,
   ...
 }: let
+  relativeMotionsKeymap = builtins.genList (n: let m = toString (n + 1); in {
+    on = m;
+    run = "plugin relative-motions ${m}";
+  }) 9;
+
   inherit (flake.config.me) namespace;
 in {
   options.${namespace}.tools.yazi.enable = lib.mkEnableOption "yazi";
@@ -70,10 +75,7 @@ in {
             run = "plugin chmod";
           }
         ]
-        ++ builtins.map (n: {
-          on = "${toString n}";
-          run = "plugin relative-motions ${toString n}";
-        }) (lib.range 1 9)
+        ++ relativeMotionsKeymap
         ++ lib.optionals git.lazygit.enable [
           {
             on = [

--- a/modules/home/tools/yazi.nix
+++ b/modules/home/tools/yazi.nix
@@ -5,10 +5,14 @@
   flake,
   ...
 }: let
-  relativeMotionsKeymap = builtins.genList (n: let m = toString (n + 1); in {
-    on = m;
-    run = "plugin relative-motions ${m}";
-  }) 9;
+  relativeMotionsKeymap =
+    builtins.genList (n: let
+      m = toString (n + 1);
+    in {
+      on = m;
+      run = "plugin relative-motions ${m}";
+    })
+    9;
 
   inherit (flake.config.me) namespace;
 in {


### PR DESCRIPTION
💡 **What:** The optimization implemented replaces the `builtins.map` over `lib.range 1 9` with a single top-level evaluation using `builtins.genList`.

🎯 **Why:** Previously, the code created a list using `lib.range`, then iterated over it using `builtins.map`, generating intermediate lists and thunks. By lifting this into a `let` binding outside the configuration tree with `builtins.genList`, the list generation happens in a single pass directly and is evaluated globally, avoiding the overhead of multiple passes and reducing garbage collection pressure.

📊 **Measured Improvement:** I was unable to establish a strict baseline because `nix` and `nix-instantiate` are not available directly in the sandbox environment to run `builtins.currentTime` evaluations. However, structurally this avoids an intermediate list allocation. While Nix functional maps are generally optimized, in very large configurations reducing total thunks generated from list operations does lead to smaller memory footprints and lower evaluation times.

---
*PR created automatically by Jules for task [15646412660850622211](https://jules.google.com/task/15646412660850622211) started by @phucisstupid*