### PR TITLE
🔒 Fix insecure curl pipeline installation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,7 +22,10 @@ If you don’t want to do all of installation manually, use my script:
 ‼️ Backup your `~/dotfiles` if you already have existing configurations
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/phucisstupid/dotflow/main/nix.sh | sh -s
+curl -fsSL https://raw.githubusercontent.com/phucisstupid/dotflow/main/nix.sh -o nix.sh
+# Inspect the script before running it
+cat nix.sh
+sh nix.sh
 ```
 
 > See the script here: [nix.sh](https://github.com/phucisstupid/dotflow/blob/main/nix.sh)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,9 +22,9 @@ If you don’t want to do all of installation manually, use my script:
 ‼️ Backup your `~/dotfiles` if you already have existing configurations
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/phucisstupid/dotflow/main/nix.sh -o nix.sh
+curl -fsSL https://raw.githubusercontent.com/phucisstupid/dotflow/main/nix.sh -o nix.sh &&
 # Inspect the script before running it
-cat nix.sh
+less nix.sh &&
 sh nix.sh
 ```
 


### PR DESCRIPTION
🎯 What: Replaced the `curl ... | sh` command in the README with instructions to download, inspect, and then run the script.
⚠️ Risk: Piping `curl` directly to `sh` is risky because network interruptions could result in executing a partially downloaded script, which might leave the system in a broken or insecure state. It also prevents the user from inspecting the script for malicious code before running it.
🛡️ Solution: Updated the documentation to first save the script (`curl -o`), prompt the user to inspect it (`cat`), and finally execute it (`sh`).

---
*PR created automatically by Jules for task [13196265126329443546](https://jules.google.com/task/13196265126329443546) started by @phucisstupid*